### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/v2/open_freebsd.go
+++ b/v2/open_freebsd.go
@@ -1,0 +1,24 @@
+// +build !windows,!darwin
+
+/*
+ * Copyright 2018-2019 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cliprompts
+
+import "os/exec"
+
+func open(url string) *exec.Cmd {
+	return nil
+}


### PR DESCRIPTION
I encountered this build failure for a project consuming cliprompts:

```
[...]
github.com/nats-io/cliprompts/v2
# github.com/nats-io/cliprompts/v2
vendor/github.com/nats-io/cliprompts/v2/open.go:21:9: undefined: open
*** Error code 2

Stop.
```

Copying the `open_linux.go` file to `open_freebsd.go` fix the issue.  I have no knowledge of go and this is a quick fix found by trial and error, maybe a more generic solution is available (e.g. building on OpenBSD or NetBSD may produce a similar error and won't be fixed by this patch)?