### PR TITLE
fix nil validator - new survey ui panics if the underlying validator is nil.

### DIFF
--- a/v2/sui.go
+++ b/v2/sui.go
@@ -40,7 +40,9 @@ func (sui *SurveyUI) Prompt(label string, value string, o ...Opt) (string, error
 
 func (sui *SurveyUI) wrap(validator Validator) survey.Validator {
 	if validator == nil {
-		return nil
+		validator = func(_ string) error {
+			return nil
+		}
 	}
 	return func(input interface{}) error {
 		s := input.(string)


### PR DESCRIPTION
This is not an issue with the library, but with how we use it. Prompt fields set the validator always, even if not set.